### PR TITLE
62 unsubscribe to a users posts

### DIFF
--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -35,20 +35,22 @@ namespace TabloidMVC.Controllers
 
         public IActionResult Details(int id)
         {
-            //will need to pass a view model with the post and any active subscriptions
+            PostDetailsViewModel pdvm = new PostDetailsViewModel();
+
             var post = _postRepository.GetPublishedPostById(id);
+            int userId = GetCurrentUserProfileId();
+
             if (post == null)
             {
-                int userId = GetCurrentUserProfileId();
                 post = _postRepository.GetUserPostById(id, userId);
                 if (post == null)
                 {
                     return NotFound();
                 }
             }
-            PostDetailsViewModel pdvm = new PostDetailsViewModel();
             pdvm.Post = post;
-            pdvm.ActiveSubscriptions = _subscriptionRepository.GetActiveSubsByAuthAndSubscriber(post.UserProfileId, GetCurrentUserProfileId());
+            pdvm.ActiveSubscription = _subscriptionRepository.GetActiveSubByAuthAndSubscriber(post.UserProfileId, userId);
+            //pass a view model with the post and any active subscriptions
             return View(pdvm);
         }
 
@@ -186,9 +188,10 @@ namespace TabloidMVC.Controllers
 
         //write a DeleteSubscription Action like the above
         [Authorize]
-        public ActionResult DeleteSubscription()
+        public ActionResult DeleteSubscription(Subscription subToDelete)
         {
-
+            _subscriptionRepository.Delete(subToDelete);
+            return RedirectToAction("Index", "Home");
         }
 
         private int GetCurrentUserProfileId()

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -35,6 +35,7 @@ namespace TabloidMVC.Controllers
 
         public IActionResult Details(int id)
         {
+            //will need to pass a view model with the post and any active subscriptions
             var post = _postRepository.GetPublishedPostById(id);
             if (post == null)
             {
@@ -45,7 +46,10 @@ namespace TabloidMVC.Controllers
                     return NotFound();
                 }
             }
-            return View(post);
+            PostDetailsViewModel pdvm = new PostDetailsViewModel();
+            pdvm.Post = post;
+            pdvm.ActiveSubscriptions = _subscriptionRepository.GetActiveSubsByAuthAndSubscriber(post.UserProfileId, GetCurrentUserProfileId());
+            return View(pdvm);
         }
 
         public IActionResult Create()
@@ -180,6 +184,12 @@ namespace TabloidMVC.Controllers
             }
         }
 
+        //write a DeleteSubscription Action like the above
+        [Authorize]
+        public ActionResult DeleteSubscription()
+        {
+
+        }
 
         private int GetCurrentUserProfileId()
         {

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -188,10 +188,19 @@ namespace TabloidMVC.Controllers
 
         //write a DeleteSubscription Action like the above
         [Authorize]
-        public ActionResult DeleteSubscription(Subscription subToDelete)
+        public ActionResult DeleteSubscription(int subToDeleteId)
         {
-            _subscriptionRepository.Delete(subToDelete);
-            return RedirectToAction("Index", "Home");
+            try
+            {
+                _subscriptionRepository.Delete(subToDeleteId);
+                return RedirectToAction("Index", "Home");
+            }
+            catch
+            {
+                // Handle errors, if any
+                return Content("Error occurred while deleting the subscription.");
+            }
+            
         }
 
         private int GetCurrentUserProfileId()

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -188,17 +188,18 @@ namespace TabloidMVC.Controllers
 
         //write a DeleteSubscription Action like the above
         [Authorize]
-        public ActionResult DeleteSubscription(int subToDeleteId)
+        public ActionResult DeleteSubscription(int subToEndId)
         {
             try
             {
-                _subscriptionRepository.Delete(subToDeleteId);
+
+                _subscriptionRepository.AddEndDate(subToEndId);
                 return RedirectToAction("Index", "Home");
             }
             catch
             {
                 // Handle errors, if any
-                return Content("Error occurred while deleting the subscription.");
+                return Content("Error occurred while ending the subscription.");
             }
             
         }

--- a/TabloidMVC/Models/Subscription.cs
+++ b/TabloidMVC/Models/Subscription.cs
@@ -9,6 +9,6 @@ namespace TabloidMVC.Models
         public int SubscriberUserProfileId { get; set; }
         public int ProviderUserProfileId { get; set; }
         public DateTime BeginDateTime { get; set; }
-        public DateTime EndDateTime { get; set; }
+        public DateTime? EndDateTime { get; set; }
     }
 }

--- a/TabloidMVC/Models/ViewModels/PostDetailsViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/PostDetailsViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+namespace TabloidMVC.Models.ViewModels
+{
+    public class PostDetailsViewModel
+    {
+        public Post Post { get; set; }
+        public Subscription ActiveSubscription { get; set; }
+    }
+}

--- a/TabloidMVC/Repositories/ISubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/ISubscriptionRepository.cs
@@ -7,5 +7,7 @@ namespace TabloidMVC.Repositories
     {
         void Add(Subscription subscription);
         Subscription GetActiveSubByAuthAndSubscriber(int authorId, int subscriberId);
+
+        void Delete(Subscription subscription);
     }
 }

--- a/TabloidMVC/Repositories/ISubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/ISubscriptionRepository.cs
@@ -1,9 +1,11 @@
-﻿using TabloidMVC.Models;
+﻿using System.Collections.Generic;
+using TabloidMVC.Models;
 
 namespace TabloidMVC.Repositories
 {
     public interface ISubscriptionRepository
     {
         void Add(Subscription subscription);
+        Subscription GetActiveSubByAuthAndSubscriber(int authorId, int subscriberId);
     }
 }

--- a/TabloidMVC/Repositories/ISubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/ISubscriptionRepository.cs
@@ -7,7 +7,7 @@ namespace TabloidMVC.Repositories
     {
         void Add(Subscription subscription);
         Subscription GetActiveSubByAuthAndSubscriber(int authorId, int subscriberId);
-
-        void Delete(int subscriptionId);
+        Subscription GetSubscriptionById(int id);
+        void AddEndDate(int subscriptionId);
     }
 }

--- a/TabloidMVC/Repositories/ISubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/ISubscriptionRepository.cs
@@ -8,6 +8,6 @@ namespace TabloidMVC.Repositories
         void Add(Subscription subscription);
         Subscription GetActiveSubByAuthAndSubscriber(int authorId, int subscriberId);
 
-        void Delete(Subscription subscription);
+        void Delete(int subscriptionId);
     }
 }

--- a/TabloidMVC/Repositories/SubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/SubscriptionRepository.cs
@@ -28,17 +28,22 @@ namespace TabloidMVC.Repositories
                     cmd.Parameters.AddWithValue("@authorId", authorId);
 
                     SqlDataReader reader = cmd.ExecuteReader();
-
+                    if (reader.Read())
+                    {
                         Subscription sub = new Subscription()
                         {
                             Id = reader.GetInt32(reader.GetOrdinal("Id")),
-                            SubscriberUserProfileId =  reader.GetInt32(reader.GetOrdinal("SubscriberUserProfileId")),
+                            SubscriberUserProfileId = reader.GetInt32(reader.GetOrdinal("SubscriberUserProfileId")),
                             ProviderUserProfileId = reader.GetInt32(reader.GetOrdinal("ProviderUserProfileId")),
                             BeginDateTime = reader.GetDateTime(reader.GetOrdinal("BeginDateTime")),
                             EndDateTime = null
                         };
-                    reader.Close();
                     return sub;
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
             }
         }
@@ -58,6 +63,21 @@ namespace TabloidMVC.Repositories
                     cmd.Parameters.AddWithValue("@provider", subscription.ProviderUserProfileId);
                     cmd.Parameters.AddWithValue("@beginDate", subscription.BeginDateTime);
                     subscription.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        public void Delete(Subscription subscription)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"DELETE Subscription
+                                        WHERE Id = @id";
+                    cmd.Parameters.AddWithValue("@id", subscription.Id);
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/TabloidMVC/Repositories/SubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/SubscriptionRepository.cs
@@ -67,7 +67,7 @@ namespace TabloidMVC.Repositories
             }
         }
 
-        public void Delete(Subscription subscription)
+        public void Delete(int Id)
         {
             using (SqlConnection conn = Connection)
             {
@@ -76,7 +76,7 @@ namespace TabloidMVC.Repositories
                 {
                     cmd.CommandText = @"DELETE Subscription
                                         WHERE Id = @id";
-                    cmd.Parameters.AddWithValue("@id", subscription.Id);
+                    cmd.Parameters.AddWithValue("@id", Id);
                     cmd.ExecuteNonQuery();
                 }
             }

--- a/TabloidMVC/Repositories/SubscriptionRepository.cs
+++ b/TabloidMVC/Repositories/SubscriptionRepository.cs
@@ -10,8 +10,41 @@ namespace TabloidMVC.Repositories
         public SubscriptionRepository(IConfiguration config) : base(config) { }
 
 
-        //need lookup by subscriberId and authorId
-        //will return list of ACTIVE subscriptions
+        //why did I build this???
+        public Subscription GetSubscriptionById(int subscriptionId)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT Id, SubscriberUserProfileId, ProviderUserProfileId, BeginDateTime, EndDateTime 
+                                        FROM Subscription
+                                        WHERE Id = @id";
+                    cmd.Parameters.AddWithValue("@id", subscriptionId);
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        Subscription sub = new Subscription()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            SubscriberUserProfileId = reader.GetInt32(reader.GetOrdinal("SubscriberUserProfileId")),
+                            ProviderUserProfileId = reader.GetInt32(reader.GetOrdinal("ProviderUserProfileId")),
+                            BeginDateTime = reader.GetDateTime(reader.GetOrdinal("BeginDateTime")),
+                            EndDateTime = reader.GetDateTime(reader.GetOrdinal("EndDateTime"))
+                        };
+                        return sub;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        //lookup by subscriberId and authorId
+        //will return only ACTIVE subscription
         public Subscription GetActiveSubByAuthAndSubscriber(int authorId, int subscriberId)
         {
             using (SqlConnection conn = Connection)
@@ -38,7 +71,7 @@ namespace TabloidMVC.Repositories
                             BeginDateTime = reader.GetDateTime(reader.GetOrdinal("BeginDateTime")),
                             EndDateTime = null
                         };
-                    return sub;
+                        return sub;
                     }
                     else
                     {
@@ -67,15 +100,16 @@ namespace TabloidMVC.Repositories
             }
         }
 
-        public void Delete(int Id)
+        public void AddEndDate(int Id)
         {
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"DELETE Subscription
-                                        WHERE Id = @id";
+                    cmd.CommandText = @"UPDATE Subscription
+                                        SET EndDateTime = GETDATE()
+                                        WHERE Id = @id;";
                     cmd.Parameters.AddWithValue("@id", Id);
                     cmd.ExecuteNonQuery();
                 }

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -16,13 +16,13 @@
             <div class="row justify-content-between">
                 <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
                 @{
-                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)))
+                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription == null)
                     {
                         <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.Post.UserProfileId })">Subscribe to @Model.Post.UserProfile.DisplayName</a>
                     }
-                    if (Model.ActiveSubscription != null)
+                    if (Model.Post.UserProfileId == int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) || Model.ActiveSubscription != null)
                     {
-                        <a href="@UrlHelperExtensions.Action("DeleteSubscription", "Post", new List<Subscription> )">Unsubscribe</a>
+                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToDelete = Model.ActiveSubscription} )">Unsubscribe</a>
                     }
                 }
                 @*conditionally render an unsubscribe button*@

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -1,49 +1,54 @@
 ﻿@using System.Security.Claims;
 
-@model TabloidMVC.Models.Post
+@model TabloidMVC.Models.ViewModels.PostDetailsViewModel
 
 @{
-    ViewData["Title"] = $"Post - {Model.Title}";
+    ViewData["Title"] = $"Post - {Model.Post.Title}";
 }
 
 <div class="container pt-5">
     <div class="post">
         <section class="px-3">
             <div class="row justify-content-between">
-                <h1 class="text-secondary">@Model.Title</h1>
-                <h1 class="text-black-50">@Model.Category.Name</h1>
+                <h1 class="text-secondary">@Model.Post.Title</h1>
+                <h1 class="text-black-50">@Model.Post.Category.Name</h1>
             </div>
             <div class="row justify-content-between">
-                <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
+                <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
                 @{
-                    if (Model.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)))
+                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)))
                     {
-                        <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.UserProfileId })">Subscribe to @Model.UserProfile.DisplayName</a>
+                        <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.Post.UserProfileId })">Subscribe to @Model.Post.UserProfile.DisplayName</a>
+                    }
+                    if (Model.ActiveSubscription != null)
+                    {
+                        <a href="@UrlHelperExtensions.Action("DeleteSubscription", "Post", new List<Subscription> )">Unsubscribe</a>
                     }
                 }
-
-                <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
+                @*conditionally render an unsubscribe button*@
+                @*Must: grab authorId, grab currentUserId, check for subscriptions*@
+                <p class="text-black-50">Published on @Html.DisplayFor(model => model.Post.PublishDateTime)</p>
             </div>
             <div class="row">
-                <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">
                     <i class="fas fa-pencil-alt"></i>
                 </a>
-                <a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                <a asp-action="Delete" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Delete">
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
         </section>
         <hr />
-        @if (!string.IsNullOrWhiteSpace(Model.ImageLocation))
+        @if (!string.IsNullOrWhiteSpace(Model.Post.ImageLocation))
         {
             <section class="row justify-content-center">
                 <div>
-                    <img src="@Model.ImageLocation" />
+                    <img src="@Model.Post.ImageLocation" />
                 </div>
             </section>
         }
         <section class="row post__content">
-            <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Content)</p>
+            <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Post.Content)</p>
         </section>
     </div>
 </div>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -20,9 +20,9 @@
                     {
                         <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.Post.UserProfileId })">Subscribe to @Model.Post.UserProfile.DisplayName</a>
                     }
-                    if (Model.Post.UserProfileId == int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) || Model.ActiveSubscription != null)
+                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription != null)
                     {
-                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToDelete = Model.ActiveSubscription} )">Unsubscribe</a>
+                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToDeleteId = Model.ActiveSubscription.Id} )">Unsubscribe</a>
                     }
                 }
                 @*conditionally render an unsubscribe button*@

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -22,7 +22,7 @@
                     }
                     if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription != null)
                     {
-                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToDeleteId = Model.ActiveSubscription.Id} )">Unsubscribe</a>
+                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToEndId = Model.ActiveSubscription.Id} )">Unsubscribe</a>
                     }
                 }
                 @*conditionally render an unsubscribe button*@


### PR DESCRIPTION
## What?
Users can now unsubscribe from current subscriptions. The subscribe link only shows up on posts not belonging to the user, where there is no active subscription to the posts author. The unsubscribe link only appears on posts not belonging to the user where there is an active subscription to the posts author.
## Why?
This is related to ticket #62. Users must be able to unsubscribe if they do not want to see an authors posts.
## How?
In the database, a subscription has a beginDate after creation but a non-existent endDate. I wrote conditional rendering that makes an "unsubscribe" link appear when this is the case. When the link is clicked, this triggers a "deleteSubscription" action. This actions uses a method from the repository to edit the active subscription to make it inactive by adding an endDate.
## Testing?
Created and 'ended' a subscription successfully