### PR TITLE
feature finished

### DIFF
--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -6,6 +6,13 @@
     ViewData["Title"] = $"Post - {Model.Post.Title}";
 }
 
+@{
+    string content = @Model.Post.Content.Trim();
+    string[] words = content.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+    int wordCount = words.Length;
+    int readTime = (int)Math.Ceiling((double)wordCount / 265);
+}
+
 <div class="container pt-5">
     <div class="post">
         <section class="px-3">
@@ -13,21 +20,31 @@
                 <h1 class="text-secondary">@Model.Post.Title</h1>
                 <h1 class="text-black-50">@Model.Post.Category.Name</h1>
             </div>
-            <div class="row justify-content-between">
-                <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
-                @{
-                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription == null)
-                    {
-                        <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.Post.UserProfileId })">Subscribe to @Model.Post.UserProfile.DisplayName</a>
+            <div class="row">
+                <div class="col">
+                    <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
+                    @{
+                        if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription == null)
+                        {
+                            <a href="@Url.Action("CreateSubscription", "Post", new { providerId = Model.Post.UserProfileId })">Subscribe to @Model.Post.UserProfile.DisplayName</a>
+                        }
+                        if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription != null)
+                        {
+                            <a href="@Url.Action("DeleteSubscription", "Post", new {subToEndId = Model.ActiveSubscription.Id} )">Unsubscribe</a>
+                        }
                     }
-                    if (Model.Post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && Model.ActiveSubscription != null)
+                </div>
+                <div class="col justify-content-end text-right">
+                    <p class="text-black-50">Published on @Html.DisplayFor(model => model.Post.PublishDateTime)</p>
+                    @if (readTime == 1)
                     {
-                        <a href="@Url.Action("DeleteSubscription", "Post", new {subToEndId = Model.ActiveSubscription.Id} )">Unsubscribe</a>
+                        <p class="text-black-50">Estimated read time: 1 minute</p>
                     }
-                }
-                @*conditionally render an unsubscribe button*@
-                @*Must: grab authorId, grab currentUserId, check for subscriptions*@
-                <p class="text-black-50">Published on @Html.DisplayFor(model => model.Post.PublishDateTime)</p>
+                    else
+                    {
+                        <p class="text-black-50">Estimated read time: @readTime minutes</p>
+                    }
+                </div>
             </div>
             <div class="row">
                 <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">


### PR DESCRIPTION
## What?
Articles now display the estimated read time.
## Why?
This helps make articles more approachable and user friendly. This satisfies the requirements of ticket #47.
## How?
Within the details view, I calculated the total number of words and divided that by the estimated reading speed of 265 words-per-minute(wpm). I then rounded up this estimate to return a number of minutes. I created optional rendering to check if the estimated time is just one minute. If so, it says "Estimated time: 1 minute" rather than "1 minutes"
## Testing?
I wrote two posts with different read times. Both were accurate. The first post was a one minute read (less than or equal to 265 wpm). The other was a three minute read (three times the length of the first)