### PR TITLE
finished feature

### DIFF
--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -65,6 +65,18 @@ namespace TabloidMVC.Controllers
             return View("FilterPostsByCategory", vm);
         }
 
+        public IActionResult PostsByAuthor(int? authorId)
+        {
+            var authorOptions = _userProfileRepository.GetAllUsersOrderedByDisplayName();
+            var posts = (authorId != null)
+                ? _postRepository.GetPublishedPostsByUserId(authorId.Value)
+                : _postRepository.GetAllPublishedPosts();
+            FilterPostByAuthorViewModel vm = new FilterPostByAuthorViewModel();
+            vm.Posts = posts;
+            vm.AllUserProfiles = authorOptions;
+            return View("FilterPostsByAuthor", vm );
+        }
+
         //GET
         public IActionResult PostApproval()
         {

--- a/TabloidMVC/Models/ViewModels/FilterPostByAuthorViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/FilterPostByAuthorViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace TabloidMVC.Models.ViewModels
+{
+    public class FilterPostByAuthorViewModel
+    {
+        public List<Post> Posts { get; set; }
+        public List<UserProfile> AllUserProfiles { get; set; }
+    }
+}

--- a/TabloidMVC/Views/Post/FilterPostsByAuthor.cshtml
+++ b/TabloidMVC/Views/Post/FilterPostsByAuthor.cshtml
@@ -1,0 +1,58 @@
+﻿@model TabloidMVC.Models.ViewModels.FilterPostByAuthorViewModel
+
+@{
+    ViewData["Title"] = "Filtered Posts By Author";
+}
+
+<div class="container pt-5">
+    <h1>Filtered Posts</h1>
+    <form asp-action="PostsByAuthor" method="get">
+        <div class="form-group">
+            <label for="authorId">Filter by Author:</label>
+            <select class="form-control" id="authorId" name="authorId">
+                <option value="">All Authors</option>
+                @foreach (var author in Model.AllUserProfiles)
+                {
+                    <option value="@author.Id">@author.DisplayName</option>
+                }
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary">Filter</button>
+    </form>
+    <table class="table table-striped">
+        <!-- Table header -->
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Author</th>
+                <th>Category</th>
+                <th>Published</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Loop through the filtered posts -->
+            @foreach (var post in Model.Posts)
+            {
+                <tr>
+                    <td>@Html.DisplayFor(modelItem => post.Title)</td>
+                    <td>@Html.DisplayFor(modelItem => post.UserProfile.DisplayName)</td>
+                    <td>@Html.DisplayFor(modelItem => post.Category.Name)</td>
+                    <td>@Html.DisplayFor(modelItem => post.PublishDateTime)</td>
+                    <td>
+                        <!-- Actions -->
+                        <a asp-action="Details" asp-route-id="@post.Id" class="btn btn-outline-primary mx-1" title="View">
+                            <i class="fas fa-eye"></i>
+                        </a>
+                        <a asp-action="Edit" asp-route-id="@post.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                            <i class="fas fa-pencil-alt"></i>
+                        </a>
+                        <a asp-action="Delete" asp-route-id="@post.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                            <i class="fas fa-trash"></i>
+                        </a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/TabloidMVC/Views/Post/Index.cshtml
+++ b/TabloidMVC/Views/Post/Index.cshtml
@@ -16,7 +16,7 @@
     </p>
     <a class="btn btn-primary" asp-action="PostsByTag">Tag</a>
     <a class="btn btn-primary" asp-action="PostsByCategory">Category</a>
-    @* <a class="btn btn-primary" asp-action="">Author</a>*@
+    <a class="btn btn-primary" asp-action="PostsByAuthor">Author</a>
     <table class="table table-striped">
         <thead>
             <tr>


### PR DESCRIPTION
## What?
Gave users a page to filter posts by author
## Why?
This makes it easier to see posts from certain authors without a subscriptions. This is useful to casual browsers, rather than dedicated fans of an author. This resolves issue ticket #49 
## How?
I followed the established pattern from Filter by Tag and Filter by Category issue tickets
## Testing?
I filtered by no author, and every single author who has posts. Feature worked as expected and listed no posts for authors without posts.